### PR TITLE
Fix spelling in "Fixing mistakes" exercise

### DIFF
--- a/exercises/Exercise6-FixingMistakes.md
+++ b/exercises/Exercise6-FixingMistakes.md
@@ -98,7 +98,7 @@ Later on, we decide that deleting `hello.template` was an accident. Let's track 
 $> git log --diff-filter=D --oneline -- hello.template
 713f6a1 Deleting hello.template
 
-# Ah, it was deleted at 713f6a1. Let's use the carrot (^) syntax to checkout hello.template from one commit before that
+# Ah, it was deleted at 713f6a1. Let's use the caret (^) syntax to checkout hello.template from one commit before that
 
 $> git checkout 713f6a1^ -- hello.template
 


### PR DESCRIPTION
"caret" not "carrot".

Thanks for this amazing workshop! :+1: 
