### PR TITLE
Add HEAD^ to git reset --hard in instructions

### DIFF
--- a/exercises/Exercise4-MergingAndReReRe.md
+++ b/exercises/Exercise4-MergingAndReReRe.md
@@ -17,7 +17,7 @@ Switched to branch 'exercise4'
 2. Use `git reset --hard HEAD^` to reset your `exercise4` branch back one commit, then use the `--no-ff` option to `git merge` to merge `exercise3` again. Look at the git log, how is it different from the last step?
 3. Make two conflicting changes to `hello.txt` in two different branches.
 4. Enable ReReRe, then merge one branch into the other.
-5. Backup again with `git reset --hard`, then attempt the merge again. Notice how ReReRe automatically resolves the conflict for you.
+5. Backup again with `git reset --hard HEAD^`, then attempt the merge again. Notice how ReReRe automatically resolves the conflict for you.
 
 ## Solutions
 

--- a/exercises/Exercise4-MergingAndReReRe.md
+++ b/exercises/Exercise4-MergingAndReReRe.md
@@ -14,7 +14,7 @@ Switched to branch 'exercise4'
 
 ### Exercise
 1. Merge the `exercise3` branch into `exercise4`, and look at the git log.
-2. Use `git reset --hard` to reset your `exercise4` branch back one commit, then use the `--no-ff` option to `git merge` to merge `exercise3` again. Look at the git log, how is it different from the last step?
+2. Use `git reset --hard HEAD^` to reset your `exercise4` branch back one commit, then use the `--no-ff` option to `git merge` to merge `exercise3` again. Look at the git log, how is it different from the last step?
 3. Make two conflicting changes to `hello.txt` in two different branches.
 4. Enable ReReRe, then merge one branch into the other.
 5. Backup again with `git reset --hard`, then attempt the merge again. Notice how ReReRe automatically resolves the conflict for you.


### PR DESCRIPTION
Add `HEAD^` to `git reset --hard` in instruction 2 of Exercise4-MergingAndReReRe so it reads: `2. Use git reset --hard HEAD^ to reset...` .