### PR TITLE
Add `git fetch` command to pull changes from the fork before setting local repo to track origin/master

### DIFF
--- a/exercises/Exercise8-ForksAndRemoteRepos.md
+++ b/exercises/Exercise8-ForksAndRemoteRepos.md
@@ -67,6 +67,18 @@ $> git checkout master
 Switched to branch 'master'
 Your branch is up-to-date with 'upstream/master'.
 
+$>git pull origin
+From github.com:mhenstell/advanced-git-exercises
+ * [new branch]      exercise10 -> origin/exercise10
+ * [new branch]      exercise2  -> origin/exercise2
+ * [new branch]      exercise3  -> origin/exercise3
+ * [new branch]      exercise4  -> origin/exercise4
+ * [new branch]      exercise5  -> origin/exercise5
+ * [new branch]      exercise6  -> origin/exercise6
+ * [new branch]      exercise7  -> origin/exercise7
+ * [new branch]      exercise9  -> origin/exercise9
+ * [new branch]      master     -> origin/master
+
 $> git branch --set-upstream-to origin/master
 Branch master set up to track local branch origin/master.
 ```


### PR DESCRIPTION
When I attempted to set up my local `master` branch to track the personal copy `origin/master` at my fork with the command:
```
git branch --set-upstream-to origin/master
```
I got an error “The requested upstream branch 'origin/master' does not exist”.

I believe the reason is that we haven't made a local copy of the branch named `master` on the remote named `origin`.

To see all the branches associated with the repo, run `git branch -a`. The output is as followed:

```
* master
  remotes/upstream/HEAD -> upstream/master
  remotes/upstream/exercise10
  remotes/upstream/exercise2
  remotes/upstream/exercise3
  remotes/upstream/exercise4
  remotes/upstream/exercise5
  remotes/upstream/exercise6
  remotes/upstream/exercise7
  remotes/upstream/exercise9
  remotes/upstream/master

```
Git is not aware of any `origin/master` branch at this point.

If I run either of these two commands: `git fetch origin`, or `git push -u origin master`, then run `git branch -a` again, the output is the same as above, but including an extra line: `remotes/origin/master`.

Then run `git branch --set-upstream-to origin/master`, then it works as expected with the message: “Branch 'master' set up to track remote branch 'master' from 'origin'.”

Hence, I propose that in the Solution section for exercise 8,  we add the `git fetch` command before `git branch --set-upstream-to` so that other learns who follow it won't be caught off guard.